### PR TITLE
Improvement: Define recursive function findBasePath explicitly  (#37)

### DIFF
--- a/src/evaluate/evaluate-expr/find-basepath.js
+++ b/src/evaluate/evaluate-expr/find-basepath.js
@@ -1,4 +1,6 @@
-module.exports = (scope) => {
+const findBasepath = (scope) => {
   if (scope.upperScope) return findBasepath(scope.upperScope);
   return scope.basepath;
-};
+}
+
+module.exports = findBasePath;


### PR DESCRIPTION
* Improvement: It doesn’t look like findBasePath is defined. But it works even though I sometimes get a runtime error for that. Yet, I defined the function explicitly.

* Use non private naming convention